### PR TITLE
[IF-990] Add to template configuration to disable cyclic rebuilds

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ terraform {
   required_providers {
     imagefactory = {
       source  = "nordcloud/imagefactory"
-      version = "1.8.0"
+      version = "1.8.1"
     }
   }
 }

--- a/docs/resources/template.md
+++ b/docs/resources/template.md
@@ -261,6 +261,7 @@ Optional:
 - `azure` (Block List) (see [below for nested schema](#nestedblock--config--azure))
 - `build_components` (Block List) (see [below for nested schema](#nestedblock--config--build_components))
 - `cloud_account_ids` (List of String)
+- `disable_cyclical_rebuilds` (Boolean) Disable cyclical rebuilds. Cyclical rebuilds are rebuilds that are triggered automatically by ImageFactory when the source image is updated or when there are security updates available for the packages installed in the image. If cyclical rebuilds are disabled, the template will not be rebuilt automatically and the user will have to trigger the rebuild manually. Default value is set to false.
 - `exoscale` (Block List) (see [below for nested schema](#nestedblock--config--exoscale))
 - `notifications` (Block List) (see [below for nested schema](#nestedblock--config--notifications))
 - `scope` (String)
@@ -272,7 +273,7 @@ Optional:
 
 Optional:
 
-- `additional_ebs_volumes` (Block List) (see [below for nested schema](#nestedblock--config--aws--additional_ebs_volumes))
+- `additional_ebs_volumes` (Block List, Max: 10) (see [below for nested schema](#nestedblock--config--aws--additional_ebs_volumes))
 - `custom_image_name` (String)
 - `region` (String)
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     imagefactory = {
       source  = "nordcloud/imagefactory"
-      version = "1.8.0"
+      version = "1.8.1"
     }
   }
 }

--- a/imagefactory/imagetemplate/schema.go
+++ b/imagefactory/imagetemplate/schema.go
@@ -232,6 +232,16 @@ var templateConfigResource = &schema.Resource{
 			ValidateFunc: validation.StringInSlice(validScopes, false),
 			Default:      graphql.ScopePUBLIC,
 		},
+		"disable_cyclical_rebuilds": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+			Description: "Disable cyclical rebuilds. " +
+				"Cyclical rebuilds are rebuilds that are triggered automatically by ImageFactory when the source image is updated or " +
+				"when there are security updates available for the packages installed in the image. If cyclical rebuilds are disabled, " +
+				"the template will not be rebuilt automatically and the user will have to trigger the rebuild manually. " +
+				"Default value is set to false.",
+		},
 	},
 }
 

--- a/imagefactory/imagetemplate/structures.go
+++ b/imagefactory/imagetemplate/structures.go
@@ -173,6 +173,11 @@ func expandTemplateConfig(in []interface{}) (*graphql.NewTemplateConfig, error) 
 		templateConfig.CloudAccountIds = &cloudAccountIDs
 	}
 
+	if m["disable_cyclical_rebuilds"] != nil {
+		disableCyclicalRebuilds := graphql.Boolean(m["disable_cyclical_rebuilds"].(bool))
+		templateConfig.DisableCyclicalRebuilds = &disableCyclicalRebuilds
+	}
+
 	return &templateConfig, nil
 }
 

--- a/pkg/graphql/graphql.go
+++ b/pkg/graphql/graphql.go
@@ -3597,15 +3597,16 @@ type NewTemplateComponentProperty struct {
 }
 
 type NewTemplateConfig struct {
-	Aws             *NewTemplateAWSConfig      `json:"aws,omitempty"`
-	Azure           *NewTemplateAZUREConfig    `json:"azure,omitempty"`
-	BuildComponents *[]NewTemplateComponent    `json:"buildComponents,omitempty"`
-	CloudAccountIds *[]String                  `json:"cloudAccountIds,omitempty"`
-	Exoscale        *NewTemplateExoscaleConfig `json:"exoscale,omitempty"`
-	Notifications   *[]NewNotification         `json:"notifications,omitempty"`
-	Scope           *Scope                     `json:"scope,omitempty"`
-	Tags            *[]NewTag                  `json:"tags,omitempty"`
-	TestComponents  *[]NewTemplateComponent    `json:"testComponents,omitempty"`
+	Aws                     *NewTemplateAWSConfig      `json:"aws,omitempty"`
+	Azure                   *NewTemplateAZUREConfig    `json:"azure,omitempty"`
+	BuildComponents         *[]NewTemplateComponent    `json:"buildComponents,omitempty"`
+	CloudAccountIds         *[]String                  `json:"cloudAccountIds,omitempty"`
+	DisableCyclicalRebuilds *Boolean                   `json:"disableCyclicalRebuilds,omitempty"`
+	Exoscale                *NewTemplateExoscaleConfig `json:"exoscale,omitempty"`
+	Notifications           *[]NewNotification         `json:"notifications,omitempty"`
+	Scope                   *Scope                     `json:"scope,omitempty"`
+	Tags                    *[]NewTag                  `json:"tags,omitempty"`
+	TestComponents          *[]NewTemplateComponent    `json:"testComponents,omitempty"`
 }
 
 type NewTemplateExoscaleConfig struct {
@@ -3908,6 +3909,7 @@ type CustomerStats struct {
 type Distribution struct {
 	ComplianceScore *ComplianceScore `json:"complianceScore,omitempty"`
 	CreatedAt       String           `json:"createdAt"`
+	Deprecated      *Boolean         `json:"deprecated,omitempty"`
 	Description     *String          `json:"description,omitempty"`
 	ID              String           `json:"id"`
 	Name            String           `json:"name"`
@@ -4174,15 +4176,16 @@ type TemplateComponentProperty struct {
 }
 
 type TemplateConfig struct {
-	Aws             *TemplateAWSConfig      `json:"aws,omitempty"`
-	Azure           *TemplateAZUREConfig    `json:"azure,omitempty"`
-	BuildComponents *[]TemplateComponent    `json:"buildComponents,omitempty"`
-	CloudAccountIds *[]String               `json:"cloudAccountIds,omitempty"`
-	Exoscale        *TemplateExoscaleConfig `json:"exoscale,omitempty"`
-	Notifications   *[]Notification         `json:"notifications,omitempty"`
-	Scope           *Scope                  `json:"scope,omitempty"`
-	Tags            *[]Tag                  `json:"tags,omitempty"`
-	TestComponents  *[]TemplateComponent    `json:"testComponents,omitempty"`
+	Aws                     *TemplateAWSConfig      `json:"aws,omitempty"`
+	Azure                   *TemplateAZUREConfig    `json:"azure,omitempty"`
+	BuildComponents         *[]TemplateComponent    `json:"buildComponents,omitempty"`
+	CloudAccountIds         *[]String               `json:"cloudAccountIds,omitempty"`
+	DisableCyclicalRebuilds *Boolean                `json:"disableCyclicalRebuilds,omitempty"`
+	Exoscale                *TemplateExoscaleConfig `json:"exoscale,omitempty"`
+	Notifications           *[]Notification         `json:"notifications,omitempty"`
+	Scope                   *Scope                  `json:"scope,omitempty"`
+	Tags                    *[]Tag                  `json:"tags,omitempty"`
+	TestComponents          *[]TemplateComponent    `json:"testComponents,omitempty"`
 }
 
 type TemplateExoscaleConfig struct {

--- a/pkg/graphql/schema.graphql
+++ b/pkg/graphql/schema.graphql
@@ -116,10 +116,6 @@ https://docs.imagefactory.nordcloudapp.com/onboarding
 """
 input AccountCredentials {
 	aws: AWSCredentials
-	aws: AWSCredentials
-	gcp: GCPCredentials
-	aws: AWSCredentials
-	gcp: GCPCredentials
 	azure: AzureCredentials
 	exoscale: ExoscaleCredentials
 	gcp: GCPCredentials
@@ -608,7 +604,7 @@ type CustomerStats {
 }
 
 
-# Copyright 2021-2022 Nordcloud Oy or its affiliates. All Rights Reserved.
+# Copyright 2021-2023 Nordcloud Oy or its affiliates. All Rights Reserved.
 
 """
 Distribution defines the cloud image that can be created by the ImageFactory.
@@ -632,6 +628,7 @@ type Distribution {
 	osLatest: Boolean
 	osEolDate: String
 	complianceScore: ComplianceScore
+	deprecated: Boolean
 }
 
 type ComplianceScore {
@@ -1021,6 +1018,7 @@ type TemplateConfig {
 	tags: [Tag!]
 	notifications: [Notification!]
 	scope: Scope
+	disableCyclicalRebuilds: Boolean
 	aws: TemplateAWSConfig
 	azure: TemplateAZUREConfig
 	exoscale: TemplateExoscaleConfig
@@ -1115,7 +1113,7 @@ input NewTemplateAWSConfig {
 	customImageName: String
 
 	"""
-	additionalEbsVolumes defines extra EBS volumes attached to the AMI image.
+	`additionalEbsVolumes` defines extra EBS volumes attached to the AMI image with a limit of 10.
 
 	"""
 	additionalEbsVolumes: [NewAdditionalEBSVolumes!]
@@ -1181,6 +1179,15 @@ input NewTemplateConfig {
 	cloudAccountIds defines a list of Cloud Account IDs to which we will distribute the image.
 	"""
 	cloudAccountIds: [String]
+
+	"""
+	disableCyclicalRebuilds defines if cyclical rebuilds are disabled for the template
+
+	Cyclical rebuilds are rebuilds that are triggered automatically by ImageFactory when the source image is updated or
+	when there are security updates available for the packages installed in the image. If cyclical rebuilds are disabled,
+	the template will not be rebuilt automatically and the user will have to trigger the rebuild manually.
+	"""
+	disableCyclicalRebuilds: Boolean
 }
 
 input NewTemplate {


### PR DESCRIPTION
## What

Cyclical rebuilds are rebuilds that are triggered automatically by ImageFactory when the source image is updated or when there are security updates available for the packages installed in the image. If cyclical rebuilds are disabled, the template will not be rebuilt automatically and the user will have to trigger the rebuild manually.